### PR TITLE
Handle request exceptions in GraphQL client

### DIFF
--- a/graphql_client.py
+++ b/graphql_client.py
@@ -18,7 +18,7 @@ from urllib.parse import urlencode
 
 import jwt as pyjwt
 import streamlit as st
-from requests import HTTPError
+from requests import RequestException
 from requests import post as requests_post
 from werkzeug.serving import make_server
 from werkzeug.wrappers import Request, Response
@@ -334,7 +334,7 @@ class GraphqlClient:
             and the second element is any errors (str, list, or None).
 
         Raises:
-            GraphqlError: If no token is set or a network error occurs.
+            GraphqlError: If no token is set or the request fails.
         """
         if not self.token:
             msg = "Authentication token is missing. Please log in."
@@ -357,7 +357,7 @@ class GraphqlClient:
                 timeout=timeout,
             )
             resp.raise_for_status()
-        except HTTPError as exc:
+        except RequestException as exc:
             raise GraphqlError(str(exc)) from exc
 
         result = resp.json()

--- a/tests/test_graphql_client.py
+++ b/tests/test_graphql_client.py
@@ -8,7 +8,7 @@ import streamlit as st
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from requests import HTTPError
+from requests import HTTPError, RequestException
 
 from graphql_client import GraphqlClient, GraphqlError
 
@@ -26,6 +26,16 @@ def test_query_raises_graphql_error_on_http_error():
     with patch("graphql_client.requests_post", return_value=mock_resp):
         with pytest.raises(GraphqlError):
             client.query("query { }")
+
+
+def test_query_raises_graphql_error_on_request_exception():
+    st.session_state["token"] = "tok"
+    client = GraphqlClient()
+    client.token = "tok"
+    with patch("graphql_client.requests_post", side_effect=RequestException("fail")):
+        with pytest.raises(GraphqlError) as exc_info:
+            client.query("query { }")
+        assert isinstance(exc_info.value.__cause__, RequestException)
 
 
 def test_query_success_returns_data():


### PR DESCRIPTION
## Summary
- raise `GraphqlError` on any `requests` failure
- test RequestException handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688a7dbf230c832d82bdf22991ba8ff1