### PR TITLE
Improve Captor login workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
 # stappcaptor
 Streamlit app for Captor marketing
+
+## Authenticating Against Captor
+
+The GraphQL API requires a Bearer token obtained from
+`https://auth.captor.se`. Tokens can be acquired either through the browser
+callback flow or by making a direct `POST` request.
+
+### Requesting a Token via `curl`
+
+```bash
+curl -X POST \
+  'https://auth.captor.se/token' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'username=<user>&password=<pass>&client_id=prod'
+```
+
+The response includes an `access_token` which can be supplied to
+`GraphqlClient`:
+
+```python
+from graphql_client import GraphqlClient
+
+client = GraphqlClient()
+client.login_with_credentials('username', 'password')
+```
+
+The token is stored in `~/.captor_streamlit` for subsequent runs.


### PR DESCRIPTION
## Summary
- document how to get an auth token from `auth.captor.se`
- support login using username and password with `login_with_credentials`
- add tests for new login flow

## Testing
- `pre-commit run --files graphql_client.py README.md tests/test_graphql_client.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_688b313dec20832da47483ec60a73a0b